### PR TITLE
shorten capture length and bump version

### DIFF
--- a/src/coda/__init__.py
+++ b/src/coda/__init__.py
@@ -1,3 +1,3 @@
 """capture youtube audio"""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/coda/coda.py
+++ b/src/coda/coda.py
@@ -84,7 +84,7 @@ async def rip_from_timestamp(interaction: discord.Interaction, url: str):
         base, ext = os.path.splitext(output_file)
         new_file = base + ".mp3"
 
-        cmd = f'ffmpeg -ss {start_seconds} -i "{output_file}" -t 5 -vn -ab 128k -ar 44100 -y "{new_file}"'
+        cmd = f'ffmpeg -ss {start_seconds} -i "{output_file}" -t 4.8 -vn -ab 128k -ar 44100 -y "{new_file}"'
         subprocess.run(cmd, shell=True)
 
         # Check the size of the file


### PR DESCRIPTION
Shorten capture length to 4.8 seconds.